### PR TITLE
Added support for http-interop/http-middleware 0.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction"
+    - COMPOSER_ARGS="--no-interaction --no-plugins"
     - COVERAGE_DEPS="satooshi/php-coveralls"
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction --no-plugins"
+    - COMPOSER_ARGS="--no-interaction"
     - COVERAGE_DEPS="satooshi/php-coveralls"
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "webimpress/http-middleware-compatibility": "^0.1.1",
+        "webimpress/http-middleware-compatibility": "^0.1.3",
         "zendframework/zend-expressive-session": "dev-feature/http-middleware-0.5"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,16 @@
     "config": {
         "sort-packages": true
     },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/webimpress/zend-expressive-session"
+        }
+    ],
     "require": {
         "php": "^7.1",
-        "http-interop/http-middleware": "^0.4.1",
-        "zendframework/zend-expressive-session": "^0.1"
+        "webimpress/http-middleware-compatibility": "^0.1.1",
+        "zendframework/zend-expressive-session": "dev-feature/http-middleware-0.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0.9",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "webimpress/http-middleware-compatibility": "^0.1.3",
+        "webimpress/http-middleware-compatibility": "^0.1.4",
         "zendframework/zend-expressive-session": "dev-feature/http-middleware-0.5"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d4efec870f29ddcad0ea79cafbe9710d",
+    "content-hash": "be8d94ed12323f7b4abbedba2f933577",
     "packages": [
         {
             "name": "http-interop/http-middleware",
@@ -159,16 +159,16 @@
         },
         {
             "name": "webimpress/composer-extra-dependency",
-            "version": "0.2.0",
+            "version": "0.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/composer-extra-dependency.git",
-                "reference": "97c241b2c80628a2cd1002cece3fc54c419b1776"
+                "reference": "31fa56391d30f03b1180c87610cbe22254780ad9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/composer-extra-dependency/zipball/97c241b2c80628a2cd1002cece3fc54c419b1776",
-                "reference": "97c241b2c80628a2cd1002cece3fc54c419b1776",
+                "url": "https://api.github.com/repos/webimpress/composer-extra-dependency/zipball/31fa56391d30f03b1180c87610cbe22254780ad9",
+                "reference": "31fa56391d30f03b1180c87610cbe22254780ad9",
                 "shasum": ""
             },
             "require": {
@@ -201,29 +201,29 @@
                 "dependency",
                 "webimpress"
             ],
-            "time": "2017-10-11T22:05:48+00:00"
+            "time": "2017-10-17T17:15:14+00:00"
         },
         {
             "name": "webimpress/http-middleware-compatibility",
-            "version": "0.1.3",
+            "version": "0.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/http-middleware-compatibility.git",
-                "reference": "5839f5abf54346eafa6617434bd5f618c0cc7adb"
+                "reference": "8ed1c2c7523dce0035b98bc4f3a73ca9cd1d3717"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/5839f5abf54346eafa6617434bd5f618c0cc7adb",
-                "reference": "5839f5abf54346eafa6617434bd5f618c0cc7adb",
+                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/8ed1c2c7523dce0035b98bc4f3a73ca9cd1d3717",
+                "reference": "8ed1c2c7523dce0035b98bc4f3a73ca9cd1d3717",
                 "shasum": ""
             },
             "require": {
                 "http-interop/http-middleware": "^0.1.1 || ^0.2 || ^0.3 || ^0.4.1 || ^0.5",
                 "php": "^5.6 || ^7.0",
-                "webimpress/composer-extra-dependency": "^0.2"
+                "webimpress/composer-extra-dependency": "^0.2.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7.22 || ^6.3.1"
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3"
             },
             "type": "library",
             "extra": {
@@ -247,7 +247,7 @@
                 "psr-15",
                 "webimpress"
             ],
-            "time": "2017-10-11T22:13:48+00:00"
+            "time": "2017-10-17T17:31:10+00:00"
         },
         {
             "name": "zendframework/zend-expressive-session",
@@ -255,12 +255,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/zend-expressive-session",
-                "reference": "52ff70b0d689681a172d32ddb66a29843a22a287"
+                "reference": "d9a997d5e8f2cc9aaab1db3275d912731cf03c77"
             },
             "require": {
                 "php": "^7.1",
                 "psr/container": "^1.0",
-                "webimpress/http-middleware-compatibility": "^0.1.3"
+                "webimpress/http-middleware-compatibility": "^0.1.4"
             },
             "conflict": {
                 "phpspec/prophecy": "<1.7.2"
@@ -333,7 +333,7 @@
                 "slack": "https://zendframework-slack.herokuapp.com",
                 "forum": "https://discourse.zendframework.com/c/questions/expressive"
             },
-            "time": "2017-10-11T22:39:23+00:00"
+            "time": "2017-10-17T18:07:07+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "11d5de930f9750919c8abba6cdb1fad1",
+    "content-hash": "d4efec870f29ddcad0ea79cafbe9710d",
     "packages": [
         {
             "name": "http-interop/http-middleware",
@@ -158,27 +158,79 @@
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
-            "name": "webimpress/http-middleware-compatibility",
-            "version": "0.1.1",
+            "name": "webimpress/composer-extra-dependency",
+            "version": "0.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webimpress/http-middleware-compatibility.git",
-                "reference": "793d21864a0417bbe01437c33f902cac49c1788c"
+                "url": "https://github.com/webimpress/composer-extra-dependency.git",
+                "reference": "97c241b2c80628a2cd1002cece3fc54c419b1776"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/793d21864a0417bbe01437c33f902cac49c1788c",
-                "reference": "793d21864a0417bbe01437c33f902cac49c1788c",
+                "url": "https://api.github.com/repos/webimpress/composer-extra-dependency/zipball/97c241b2c80628a2cd1002cece3fc54c419b1776",
+                "reference": "97c241b2c80628a2cd1002cece3fc54c419b1776",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.5.2",
+                "mikey179/vfsstream": "^1.6.5",
+                "phpunit/phpunit": "^5.7.22 || ^6.4.1",
+                "zendframework/zend-coding-standard": "~1.0.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Webimpress\\ComposerExtraDependency\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webimpress\\ComposerExtraDependency\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Composer plugin to require extra dependencies",
+            "homepage": "https://github.com/webimpress/composer-extra-dependency",
+            "keywords": [
+                "composer",
+                "dependency",
+                "webimpress"
+            ],
+            "time": "2017-10-11T22:05:48+00:00"
+        },
+        {
+            "name": "webimpress/http-middleware-compatibility",
+            "version": "0.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/http-middleware-compatibility.git",
+                "reference": "5839f5abf54346eafa6617434bd5f618c0cc7adb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/5839f5abf54346eafa6617434bd5f618c0cc7adb",
+                "reference": "5839f5abf54346eafa6617434bd5f618c0cc7adb",
                 "shasum": ""
             },
             "require": {
                 "http-interop/http-middleware": "^0.1.1 || ^0.2 || ^0.3 || ^0.4.1 || ^0.5",
-                "php": "^5.6 || ^7.0"
+                "php": "^5.6 || ^7.0",
+                "webimpress/composer-extra-dependency": "^0.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7.22 || ^6.3.1"
             },
             "type": "library",
+            "extra": {
+                "dependency": [
+                    "http-interop/http-middleware"
+                ]
+            },
             "autoload": {
                 "files": [
                     "autoload/http-middleware.php"
@@ -195,7 +247,7 @@
                 "psr-15",
                 "webimpress"
             ],
-            "time": "2017-10-05T15:55:30+00:00"
+            "time": "2017-10-11T22:13:48+00:00"
         },
         {
             "name": "zendframework/zend-expressive-session",
@@ -203,12 +255,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/zend-expressive-session",
-                "reference": "c213e53add39bf19c18506a837196c39b92a876f"
+                "reference": "52ff70b0d689681a172d32ddb66a29843a22a287"
             },
             "require": {
                 "php": "^7.1",
                 "psr/container": "^1.0",
-                "webimpress/http-middleware-compatibility": "^0.1.1"
+                "webimpress/http-middleware-compatibility": "^0.1.3"
             },
             "conflict": {
                 "phpspec/prophecy": "<1.7.2"
@@ -281,7 +333,7 @@
                 "slack": "https://zendframework-slack.herokuapp.com",
                 "forum": "https://discourse.zendframework.com/c/questions/expressive"
             },
-            "time": "2017-10-11T15:39:21+00:00"
+            "time": "2017-10-11T22:39:23+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f41df865bca84cc93bfcd1635d44e65c",
+    "content-hash": "11d5de930f9750919c8abba6cdb1fad1",
     "packages": [
         {
             "name": "http-interop/http-middleware",
@@ -158,23 +158,60 @@
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
-            "name": "zendframework/zend-expressive-session",
-            "version": "0.1.0",
+            "name": "webimpress/http-middleware-compatibility",
+            "version": "0.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/zend-expressive-session.git",
-                "reference": "9e44991582955359ee48bb4f786ed064809baf80"
+                "url": "https://github.com/webimpress/http-middleware-compatibility.git",
+                "reference": "793d21864a0417bbe01437c33f902cac49c1788c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-session/zipball/9e44991582955359ee48bb4f786ed064809baf80",
-                "reference": "9e44991582955359ee48bb4f786ed064809baf80",
+                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/793d21864a0417bbe01437c33f902cac49c1788c",
+                "reference": "793d21864a0417bbe01437c33f902cac49c1788c",
                 "shasum": ""
             },
             "require": {
-                "http-interop/http-middleware": "^0.4.1",
+                "http-interop/http-middleware": "^0.1.1 || ^0.2 || ^0.3 || ^0.4.1 || ^0.5",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.22 || ^6.3.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "autoload/http-middleware.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Compatibility library for Draft PSR-15 HTTP Middleware",
+            "homepage": "https://github.com/webimpress/http-middleware-compatibility",
+            "keywords": [
+                "middleware",
+                "psr-15",
+                "webimpress"
+            ],
+            "time": "2017-10-05T15:55:30+00:00"
+        },
+        {
+            "name": "zendframework/zend-expressive-session",
+            "version": "dev-feature/http-middleware-0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/zend-expressive-session",
+                "reference": "c213e53add39bf19c18506a837196c39b92a876f"
+            },
+            "require": {
                 "php": "^7.1",
-                "psr/container": "^1.0"
+                "psr/container": "^1.0",
+                "webimpress/http-middleware-compatibility": "^0.1.1"
+            },
+            "conflict": {
+                "phpspec/prophecy": "<1.7.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^6.0.9",
@@ -199,20 +236,52 @@
                     "Zend\\Expressive\\Session\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\Expressive\\Session\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@cs-check",
+                    "@test"
+                ],
+                "cs-check": [
+                    "phpcs"
+                ],
+                "cs-fix": [
+                    "phpcbf"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --colors=always --coverage-clover clover.xml"
+                ],
+                "upload-coverage": [
+                    "coveralls -v"
+                ]
+            },
             "license": [
                 "BSD-3-Clause"
             ],
             "description": "Session container and middleware for PSR-7 applications",
             "keywords": [
-                "ZendFramework",
                 "expressive",
                 "middleware",
                 "psr-7",
                 "session",
+                "zendframework",
                 "zf"
             ],
-            "time": "2017-10-10T18:50:17+00:00"
+            "support": {
+                "docs": "https://docs.zendframework.com/zend-expressive-session/",
+                "issues": "https://github.com/zendframework/zend-expressive-session/issues",
+                "source": "https://github.com/zendframework/zend-expressive-session",
+                "slack": "https://zendframework-slack.herokuapp.com",
+                "forum": "https://discourse.zendframework.com/c/questions/expressive"
+            },
+            "time": "2017-10-11T15:39:21+00:00"
         }
     ],
     "packages-dev": [
@@ -1775,7 +1844,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "zendframework/zend-expressive-session": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/Exception/MissingSessionException.php
+++ b/src/Exception/MissingSessionException.php
@@ -7,8 +7,8 @@
 
 namespace Zend\Expressive\Flash\Exception;
 
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use RuntimeException;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 
 class MissingSessionException extends RuntimeException implements ExceptionInterface
 {

--- a/src/FlashMessageMiddleware.php
+++ b/src/FlashMessageMiddleware.php
@@ -7,12 +7,14 @@
 
 namespace Zend\Expressive\Flash;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use Zend\Expressive\Session\SessionInterface;
 use Zend\Expressive\Session\SessionMiddleware;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class FlashMessageMiddleware implements MiddlewareInterface
 {
@@ -58,6 +60,6 @@ class FlashMessageMiddleware implements MiddlewareInterface
 
         $flashMessages = ($this->flashMessageFactory)($session, $this->sessionKey);
 
-        return $delegate->process($request->withAttribute($this->attributeKey, $flashMessages));
+        return $delegate->{HANDLER_METHOD}($request->withAttribute($this->attributeKey, $flashMessages));
     }
 }

--- a/test/FlashMessageMiddlewareTest.php
+++ b/test/FlashMessageMiddlewareTest.php
@@ -7,17 +7,19 @@
 
 namespace ZendTest\Expressive\Flash;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use stdClass;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Zend\Expressive\Flash\Exception;
 use Zend\Expressive\Flash\FlashMessageMiddleware;
 use Zend\Expressive\Flash\FlashMessagesInterface;
 use Zend\Expressive\Session\SessionInterface;
 use Zend\Expressive\Session\SessionMiddleware;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class FlashMessageMiddlewareTest extends TestCase
 {
@@ -45,7 +47,7 @@ class FlashMessageMiddlewareTest extends TestCase
         )->shouldNotBeCalled();
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process(Argument::type(ServerRequestInterface::class))->shouldNotBeCalled();
+        $delegate->{HANDLER_METHOD}(Argument::type(ServerRequestInterface::class))->shouldNotBeCalled();
 
         $middleware = new FlashMessageMiddleware();
 
@@ -73,7 +75,7 @@ class FlashMessageMiddlewareTest extends TestCase
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process(Argument::that([$request, 'reveal']))->willReturn($response);
+        $delegate->{HANDLER_METHOD}(Argument::that([$request, 'reveal']))->willReturn($response);
 
         $middleware = new FlashMessageMiddleware(
             TestAsset\FlashMessages::class,


### PR DESCRIPTION
Requires https://github.com/zendframework/zend-expressive-session/pull/2 to be merged and released first. Then `composer.json` should be updated in this repository to point released version of `zend-expressive-session`.