### PR TITLE
FIx error with resolve Psr\Http\Server\MiddlewareInterface

### DIFF
--- a/src/Exception/MissingSessionException.php
+++ b/src/Exception/MissingSessionException.php
@@ -7,7 +7,8 @@
 
 namespace Zend\Expressive\Flash\Exception;
 
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Psr\Http\Server\MiddlewareInterface;
+
 use RuntimeException;
 
 class MissingSessionException extends RuntimeException implements ExceptionInterface

--- a/src/FlashMessageMiddleware.php
+++ b/src/FlashMessageMiddleware.php
@@ -8,9 +8,10 @@
 namespace Zend\Expressive\Flash;
 
 use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Expressive\Session\SessionInterface;
 use Zend\Expressive\Session\SessionMiddleware;
 
@@ -49,7 +50,7 @@ class FlashMessageMiddleware implements MiddlewareInterface
         $this->attributeKey = $attributeKey;
     }
 
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate) : ResponseInterface
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $session = $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE, false);
         if (! $session instanceof SessionInterface) {
@@ -58,6 +59,6 @@ class FlashMessageMiddleware implements MiddlewareInterface
 
         $flashMessages = ($this->flashMessageFactory)($session, $this->sessionKey);
 
-        return $delegate->process($request->withAttribute($this->attributeKey, $flashMessages));
+        return $handler->handle($request->withAttribute($this->attributeKey, $flashMessages));
     }
 }


### PR DESCRIPTION
Zend Expressive 3 throw error Service `Service "Zend\Expressive\Flash\FlashMessageMiddleware" did not to resolve to a Psr\Http\Server\MiddlewareInterface instance; resolved to "Zend\Expressive\Flash\FlashMessageMiddleware"`.
This PR will fix this problem.